### PR TITLE
Bump pdfbox from 2.0.7 to 2.0.24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
-            <version>2.0.7</version>
+            <version>2.0.24</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.poi/poi -->
         <dependency>


### PR DESCRIPTION
Bumps pdfbox from 2.0.7 to 2.0.24.

---
updated-dependencies:
- dependency-name: org.apache.pdfbox:pdfbox dependency-type: direct:production ...